### PR TITLE
Implemented quadratic XP scaling

### DIFF
--- a/Main/UI/InGame/XpUI/baseXpUI.tscn
+++ b/Main/UI/InGame/XpUI/baseXpUI.tscn
@@ -182,6 +182,7 @@ metadata/_edit_lock_ = true
 
 [node name="BackGradient" type="TextureRect" parent="Minimized"]
 layout_direction = 1
+layout_mode = 0
 offset_right = 129.0
 offset_bottom = 172.0
 scale = Vector2(2, 0.1)
@@ -198,6 +199,7 @@ offset_bottom = 14.0
 
 [node name="HBoxContainer" type="HBoxContainer" parent="Minimized"]
 custom_minimum_size = Vector2(100, 0)
+layout_mode = 0
 offset_top = -7.0
 offset_right = 157.0
 offset_bottom = 15.0
@@ -249,6 +251,7 @@ layout_mode = 2
 metadata/_edit_lock_ = true
 
 [node name="WeaponLevel" type="Label" parent="Minimized"]
+layout_mode = 0
 offset_left = 197.0
 offset_top = -4.0
 offset_right = 238.0
@@ -260,6 +263,7 @@ vertical_alignment = 1
 metadata/_edit_lock_ = true
 
 [node name="LevelUp" type="TextureRect" parent="Minimized"]
+layout_mode = 0
 offset_left = 235.0
 offset_top = 1.0
 offset_right = 335.0

--- a/Main/UI/InGame/XpUI/base_xp_ui.gd
+++ b/Main/UI/InGame/XpUI/base_xp_ui.gd
@@ -132,8 +132,8 @@ func set_ability_cooldown_ui(time: float):
 # weapon xp changes
 func set_new_xp_ui(xp: float):
 	var initial_value: float = xp
-	while initial_value > weapon_node.upgrade_quota:
-		initial_value -= weapon_node.upgrade_quota
+	active_xp_progress_bar.max_value = weapon_node.upgrade_quota
+	minimized_xp_progress_bar.max_value = weapon_node.upgrade_quota
 	active_xp_progress_bar.value = initial_value
 	minimized_xp_progress_bar.value = initial_value
 	#print("setting value to: " + str(initial_value) +  " for " + str(weapon_node))

--- a/Main/Weapons/Middle/middle.tscn
+++ b/Main/Weapons/Middle/middle.tscn
@@ -40,7 +40,7 @@ radius = 1.435
 [node name="Middle" type="Node3D"]
 script = ExtResource("1_l4hd8")
 shield_duration = 2.0
-upgrade_quota = 400.0
+upgrade_quota = 250.0
 degradation = 7.1
 expected_usage = 70
 expected_usage_rate = 30


### PR DESCRIPTION
- Added quadratic scaling of XP requirements
- Modified XP bar to reflect these requirements
- Fixed the experience rate division error

The "upgrade quota" variable now increases by 1.5x per level (may be adjusted for game balancing). If quadratic scaling is not desired, simply just increase by 1.0x.

When calculating experience rate, the division used was actually integer division (unintended). Modified now to be float division.